### PR TITLE
Upgrade tooling and minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.22</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
   <artifactId>applitools-eyes</artifactId>
@@ -30,11 +30,9 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.625.3</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
-    <plugins.workflow.version>1.15</plugins.workflow.version>
-    <plugins.job-dsl.version>1.52</plugins.job-dsl.version>
+    <jenkins.version>2.303.3</jenkins.version>
+    <!-- <= 1.71 vulnerable: https://www.jenkins.io/security/advisory/2019-03-06/#SECURITY-1342 -->
+    <plugins.job-dsl.version>1.72</plugins.job-dsl.version>
   </properties>
 
   <developers>
@@ -44,17 +42,26 @@
       <email>team@applitools.com</email>
     </developer>
   </developers>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1409.v7659b_c072f18</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>${plugins.workflow.version}</version>
       </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-job</artifactId>
-          <version>${plugins.workflow.version}</version>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/applitools/jenkins/ApplitoolsEnvironmentExpander.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsEnvironmentExpander.java
@@ -1,10 +1,11 @@
 package com.applitools.jenkins;
-import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
-import java.util.Map;
-import java.util.HashMap;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
+import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
+
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by addihorowitz on 5/7/17.
@@ -19,7 +20,7 @@ public class ApplitoolsEnvironmentExpander extends EnvironmentExpander {
     }
 
     @Override
-    public void expand(@Nonnull EnvVars env) throws IOException, InterruptedException {
+    public void expand(@NonNull EnvVars env) throws IOException, InterruptedException {
         env.overrideAll(overrides);
     }
 }

--- a/src/main/java/com/applitools/jenkins/ApplitoolsStep.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsStep.java
@@ -1,21 +1,21 @@
 package com.applitools.jenkins;
+import com.google.inject.Inject;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
+import hudson.Extension;
 import hudson.model.*;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.steps.*;
-import org.kohsuke.stapler.DataBoundConstructor;
-import hudson.Extension;
-import org.kohsuke.stapler.StaplerRequest;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
-import java.util.HashMap;
-import javax.annotation.Nonnull;
-import com.google.inject.Inject;
-import hudson.EnvVars;
 import java.util.Collections;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
+
 /**
  * Created by addihorowitz on 5/7/17.
  */
@@ -105,7 +105,7 @@ public class ApplitoolsStep extends AbstractStepImpl {
         }
 
         @Override
-        public void stop(@Nonnull Throwable cause) throws Exception {
+        public void stop(@NonNull Throwable cause) throws Exception {
             if (body!=null) {
                 body.cancel(cause);
             }


### PR DESCRIPTION
Hi,

I thought it'd be useful to modernize this plugin to help with maintenance.


- Bump Jenkins version to 2.303.3 as per [the recommendation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/). Being on a version this old forces several implied dependencies we don't use.
- Upgrade parent pom to 4.40 to support testing against Java 17
- Remove deprecated java.level property
- Rely on plugins bom for workflow plugins versions
- Bump JobDSL to 1.72 to rely on non-vulnerable version and fix issue with forked XStream dependency
- Migrate to Spotbugs annotations from `javax.annotations`

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
