### PR TITLE
Improve batch id archive process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [vNext] - dNext
+### Updated
+- Check if using a custom batch id before archiving it. [Trello 2201](https://trello.com/c/B8KrpLpF)
+- Update `jenkins.version` to version `2.361.4` as [recommended here](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).
+- Update parent pom to `4.51`.
+- Remove deprecated `java.level` property.
+- Bump JobDSL to `1.72` to rely on non-vulnerable version.
+- Rely on Jenkins core BOM for workflow plugins versions.
+
 ## [1.12] - 2019-11-13
 ### Added
 - Allow setting Batch ID explicitly. 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.22</version>
+    <version>4.51</version>
     <relativePath />
   </parent>
   <artifactId>applitools-eyes</artifactId>
@@ -30,11 +30,10 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.625.3</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
-    <plugins.workflow.version>1.15</plugins.workflow.version>
-    <plugins.job-dsl.version>1.52</plugins.job-dsl.version>
+    <!-- Recommended version: https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.version>2.361.4</jenkins.version>
+    <!-- <= 1.71 vulnerable: https://www.jenkins.io/security/advisory/2019-03-06/#SECURITY-1342 -->
+    <plugins.job-dsl.version>1.72</plugins.job-dsl.version>
   </properties>
 
   <developers>
@@ -45,16 +44,26 @@
     </developer>
   </developers>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1409.v7659b_c072f18</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>${plugins.workflow.version}</version>
       </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-job</artifactId>
-          <version>${plugins.workflow.version}</version>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
@@ -70,7 +70,6 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
                 if (isCustomBatchId) {
-                    listener.getLogger().println(String.format("tearDown save artifact: " + isCustomBatchId));
                     build.pickArtifactManager().archive(build.getWorkspace(), launcher, listener, ARTIFACT_PATHS);
                 }
                 ApplitoolsCommon.closeBatch(build, listener, serverURL, notifyByCompletion, applitoolsApiKey);

--- a/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
@@ -31,6 +31,8 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
     public boolean notifyByCompletion;
     public String applitoolsApiKey;
 
+    private static boolean isCustomBatchId = false;
+
     static final Map<String, String> ARTIFACT_PATHS = new HashMap();
 
     static {
@@ -67,7 +69,10 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
         return new Environment() {
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-                build.pickArtifactManager().archive(build.getWorkspace(), launcher, listener, ARTIFACT_PATHS);
+                if (isCustomBatchId) {
+                    listener.getLogger().println(String.format("tearDown save artifact: " + isCustomBatchId));
+                    build.pickArtifactManager().archive(build.getWorkspace(), launcher, listener, ARTIFACT_PATHS);
+                }
                 ApplitoolsCommon.closeBatch(build, listener, serverURL, notifyByCompletion, applitoolsApiKey);
                 return true;
             }
@@ -92,8 +97,10 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
                     Matcher m = ApplitoolsCommon.artifactRegexp.matcher(apath.getKey());
                     if (m.find()) {
                         applitoolsArtifacts.put(m.group(1), value);
+                        isCustomBatchId = true;
                     }
                 } catch (IOException e) {
+                    isCustomBatchId = false;
                     listener.getLogger().println(String.format("Custom BATCH_ID is not defined: %s", rootDir.child(apath.getValue())));
                 }
             }


### PR DESCRIPTION
[Trello 2201](https://trello.com/c/B8KrpLpF/2201).

Update the behavior of archiving the `APPLITOOLS_BATCH_ID` at the end of a job to be executed only of a custom batch ID (`BATCH_ID` file) was used.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
