### PR TITLE
Fixed the Applitools Plugin for newer versions of Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.22</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>7</java.level>
     <plugins.workflow.version>1.15</plugins.workflow.version>
@@ -62,12 +62,19 @@
           <version>${plugins.job-dsl.version}</version>
           <optional>true</optional>
         </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-htmlunit</artifactId>
+      <version>2.18-1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
+    </dependency>
   </dependencies>
   <repositories>
-    <repository>
-      <id>m.g.o-public</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
     <repository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>

--- a/src/main/java/com/applitools/jenkins/ApplitoolsStatusDisplayAction.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsStatusDisplayAction.java
@@ -53,7 +53,10 @@ public class ApplitoolsStatusDisplayAction extends AbstractApplitoolsStatusDispl
 
     @Override
     public String getIframeText() {
-        this.applitoolsValuesFromArtifacts = ApplitoolsCommon.checkApplitoolsArtifacts(this.build.getArtifacts(), this.build.getArtifactManager().root());
+        this.applitoolsValuesFromArtifacts = 
+            ApplitoolsCommon.checkApplitoolsArtifacts(
+                this.build.getArtifacts(), 
+                this.build.getArtifactManager().root());
         try{
             String iframeURL = generateIframeURL();
             if (iframeURL == null)
@@ -92,35 +95,15 @@ public class ApplitoolsStatusDisplayAction extends AbstractApplitoolsStatusDispl
         return serverURL + "/app/batchesnoauth/?startInfoBatchId=" + generateBatchId() + "&hideBatchList=true&intercom=false&agentId=eyes-jenkins-1.13";
     }
 
-//    private void checkApplitoolsArtifacts() {
-//        this.applitoolsValuesFromArtifacts = new HashMap();
-//        ArtifactManager artifactManager = build.getArtifactManager();
-//        List<Run.Artifact> artifactList = build.getArtifacts();
-//        if (artifactList.size() > 0 && artifactManager != null) {
-//            for (Run.Artifact artifact : artifactList) {
-//                String artifactFileName = artifact.getFileName();
-//                Matcher m = artifactRegexp.matcher(artifactFileName);
-//                if (m.find()) {
-//                  String artifactName = m.group(1);
-//                  try {
-//                      InputStream stream = artifactManager.root().child(artifactFileName).open();
-//                      String value = IOUtils.toString(stream, StandardCharsets.UTF_8.name()).replaceAll(System.getProperty("line.separator"), "");
-//                      this.applitoolsValuesFromArtifacts.put(artifactName, value);
-//                  } catch (java.io.IOException e) {
-//                      logger.warning("Could't get artifact " + artifactFileName + "." + e.getMessage());
-//                  }
-//                }
-//            }
-//        }
-//    }
-
     public static String generateBatchId(String projectName, int buildNumber, Calendar buildTimestamp) {
       return generateBatchId(projectName, buildNumber, buildTimestamp, null);
     }
 
-    public static String generateBatchId(String projectName, int buildNumber, Calendar buildTimestamp, Map<String, String> applitoolsValuesFromArtifacts)
+    public static String generateBatchId(String projectName, int buildNumber, Calendar buildTimestamp,
+                                         Map<String, String> applitoolsValuesFromArtifacts)
     {
-        if (applitoolsValuesFromArtifacts != null && applitoolsValuesFromArtifacts.containsKey(ApplitoolsEnvironmentUtil.APPLITOOLS_BATCH_ID)) {
+        if (applitoolsValuesFromArtifacts != null &&
+                applitoolsValuesFromArtifacts.containsKey(ApplitoolsEnvironmentUtil.APPLITOOLS_BATCH_ID)) {
             return applitoolsValuesFromArtifacts.get(ApplitoolsEnvironmentUtil.APPLITOOLS_BATCH_ID);
         } else {
             final String BATCH_ID_PREFIX = "jenkins";


### PR DESCRIPTION
Fixed the Applitools Plugin for newer versions of Jenkins, by using other method for REST communication.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
