### PR TITLE
Remove Jenkins test harness from hpi file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,6 @@
           <optional>true</optional>
         </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness-htmlunit</artifactId>
-      <version>2.18-1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.6</version>

--- a/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
@@ -1,10 +1,10 @@
 package com.applitools.jenkins;
 
-import hidden.jth.org.apache.http.client.methods.HttpDelete;
-import hidden.jth.org.apache.http.client.methods.HttpUriRequest;
-import hidden.jth.org.apache.http.client.utils.URIBuilder;
-import hidden.jth.org.apache.http.impl.client.HttpClientBuilder;
-import hidden.jth.org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.client.HttpClient;
 import hudson.model.JobProperty;
 import hudson.model.Run;
 import hudson.model.TaskListener;


### PR DESCRIPTION
## Remove Jenkins test harness HTMLUnit from the plugin hpi file

https://github.com/jenkinsci/jenkins/pull/8714 included in Jenkins 2.434 and later will refuse to load a plugin that includes the Jenkins test harness.

The Jenkins test harness causes unexpected failures when it is included in a Jenkins plugin.  Refer to the following issue reports for examples:

* https://issues.jenkins.io/browse/JENKINS-65650
* https://issues.jenkins.io/browse/JENKINS-66060
* https://issues.jenkins.io/browse/JENKINS-72353

The additional benefit of the change is that it makes the plugin hpi file over 80% smaller.

Before this change, the plugin hpi file had the following contents:

```
  1136 META-INF/MANIFEST.MF
    73 META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.properties
  3153 META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.xml
 34814 WEB-INF/lib/applitools-eyes.jar
353793 WEB-INF/lib/commons-codec-1.15.jar
588337 WEB-INF/lib/commons-collections-3.2.2.jar
327135 WEB-INF/lib/commons-io-2.11.0.jar
434678 WEB-INF/lib/commons-lang3-3.4.jar
380196 WEB-INF/lib/cssparser-0.9.16.jar
767140 WEB-INF/lib/httpclient-4.5.6.jar
326356 WEB-INF/lib/httpcore-4.4.10.jar
4079701 WEB-INF/lib/jenkins-test-harness-htmlunit-2.18-1.jar
108240 WEB-INF/lib/jetty-io-9.2.12.v20150709.jar
357855 WEB-INF/lib/jetty-util-9.2.12.v20150709.jar
125315 WEB-INF/lib/nekohtml-1.9.22.jar
 15808 WEB-INF/lib/sac-1.3.jar
276420 WEB-INF/lib/serializer-2.7.2.jar
 43776 WEB-INF/lib/websocket-api-9.2.12.v20150709.jar
 36264 WEB-INF/lib/websocket-client-9.2.12.v20150709.jar
179845 WEB-INF/lib/websocket-common-9.2.12.v20150709.jar
3154938 WEB-INF/lib/xalan-2.7.2.jar
1367760 WEB-INF/lib/xercesImpl-2.11.0.jar
220536 WEB-INF/lib/xml-apis-1.4.01.jar
 10963 WEB-INF/licenses.xml
```

After this change, the plugin hpi file has the following contents:

```
  1136 META-INF/MANIFEST.MF
    73 META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.properties
  2951 META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.xml
 34479 WEB-INF/lib/applitools-eyes.jar
353793 WEB-INF/lib/commons-codec-1.15.jar
767140 WEB-INF/lib/httpclient-4.5.6.jar
326356 WEB-INF/lib/httpcore-4.4.10.jar
  1814 WEB-INF/licenses.xml
```

### Testing done

Confirmed that compilation, test, and packaging of the plugin behaves as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
