### PR TITLE
Use development version numbers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>applitools-eyes</artifactId>
-  <version>1.14.1</version>
+  <version>1.15.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Applitools Eyes Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Applitools+Eyes+Plugin</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:https://github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>applitools-eyes-1.14.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.62</version>
+    <version>4.76</version>
     <relativePath />
   </parent>
   <artifactId>applitools-eyes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.303.x</artifactId>
-        <version>1409.v7659b_c072f18</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2102.v854b_fec19c92</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,8 @@
           <optional>true</optional>
         </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.6</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
## Use development version numbers

Version 1.15.0 and 1.15.1 of the plugin have been released to the Jenkins update center, even though there is no tag in the repository for those releases.

Avoid user confusion by setting the version number to 1.15.2-SNAPSHOT.

When the maintainer performs `mvn release:prepare release:perform`, Apache Maven will prompt for a new version number and will suggest 1.15.2.  The maintainer can press enter to accept the recommendation and Apache Maven will create two commits, one that sets the release to 1.15.2 and then a second that sets it to 1.15.3-SNAPSHOT.

### Depend on Apache httpclient 4 plugin instead of jar file

https://plugins.jenkins.io/apache-httpcomponents-client-4-api/ avoids the plugin bundling an outdated version of the Apache httpclient library.  It replaces the bundling of the jar file with a dependency on the Apache HttpComponents Client 4.x API plugin.  That plugin is installed on over 96% of all Jenkins installations.

By depending on the plugin instead of the jar file, the plugin bill of materials will manage the dependency version and the plugin will use the most recent version that is installed on the Jenkins controller.

This is a common technique used by many Jenkins plugins.  Refer to https://plugins.jenkins.io/apache-httpcomponents-client-4-api/dependencies/ for the list of plugins that depend on the Apache httpclient plugin.

### Use bom-2.361.x to match Jenkins minimum version

The Jenkins plugin bill of materials dependency should match the Jenkins minimum version from the `jenkins.version` property.  Refer to https://www.jenkins.io/doc/developer/tutorial-improve/use-plugin-bill-of-materials/ for more details about the plugin bill of materials.

### Use most recent parent pom - 4.76

Allows compilation with Java 11, Java 17, and Java 21.  Preparing for Oct 2024 when Java 11 support in Jenkins will be end of life.

### Add Jenkinsfile to check plugin on ci.jenkins.io

https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/ describes the benefits of including a Jenkinsfile in the plugin repository.  This will provide a ci.jenkins.io job that evaluates the master branch and any pull request branches automatically.

### Testing done

Interactive tests confirmed that the correct plugin version is displayed to the user.  Interactive tests also confirmed that the Apache httpclient library dependency was added as expected.  Compilation messages no longer report that a transitive dependency on an older Apache httpclient library is being added to the hpi file.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

### Additional notes

Confirmed that the contents of the plugin hpi file are further simplified so that the plugin hpi file now contains:

```
M    Mode     Size        Date&time         Filename
- ----------  -----  --------------------  ----------------
  drwxr-xr-x      0   7-Jan-2024 06:11:14  META-INF/
  -rw-r--r--   1215   7-Jan-2024 06:11:14  META-INF/MANIFEST.MF
  drwxr-xr-x      0   7-Jan-2024 06:11:14  WEB-INF/
  drwxr-xr-x      0   7-Jan-2024 06:11:14  WEB-INF/lib/
  drwxr-xr-x      0   7-Jan-2024 06:11:14  META-INF/maven/
  drwxr-xr-x      0   7-Jan-2024 06:11:14  META-INF/maven/org.jenkins-ci.plugins/
  drwxr-xr-x      0   7-Jan-2024 06:11:14  META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/
  -rw-r--r--    549   7-Jan-2024 06:11:12  WEB-INF/licenses.xml
  -rw-r--r--  34820   7-Jan-2024 06:11:12  WEB-INF/lib/applitools-eyes.jar
  -rw-r--r--   2794   7-Jan-2024 06:11:08  META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.xml
  -rw-r--r--     82   7-Jan-2024 06:11:14  META-INF/maven/org.jenkins-ci.plugins/applitools-eyes/pom.properties
- ----------  -----  --------------------  ----------------
              39460                         11 files
```

The change removed several dependencies that were being included as transitive dependencies.
