### PR TITLE
use Secret and <f:password /> for Api Key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>applitools-eyes</artifactId>
-    <version>1.16.5</version>
+    <version>1.16.6</version>
     <packaging>hpi</packaging>
     <name>Applitools Eyes Plugin</name>
     <url>https://github.com/jenkinsci/applitools-eyes-plugin</url>

--- a/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsBuildWrapper.java
@@ -12,6 +12,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
+
+import hudson.util.Secret;
 import jenkins.util.VirtualFile;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -26,7 +28,7 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
     public final static String BATCH_NOTIFICATION_PATH = "/api/sessions/batches/%s/close/bypointerid";
     public String serverURL;
     public boolean notifyOnCompletion;
-    public String applitoolsApiKey;
+    public Secret applitoolsApiKey;
     public boolean dontCloseBatches;
     public boolean eyesScmIntegrationEnabled;
     static boolean isCustomBatchId = false;
@@ -46,7 +48,7 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
 
     @DataBoundConstructor
     public ApplitoolsBuildWrapper(String serverURL, boolean notifyOnCompletion,
-                                  String applitoolsApiKey, boolean dontCloseBatches, boolean eyesScmIntegrationEnabled) {
+                                  Secret applitoolsApiKey, boolean dontCloseBatches, boolean eyesScmIntegrationEnabled) {
         this.applitoolsApiKey = applitoolsApiKey;
         this.notifyOnCompletion = notifyOnCompletion;
         this.dontCloseBatches = dontCloseBatches;
@@ -183,7 +185,7 @@ public class ApplitoolsBuildWrapper extends BuildWrapper implements Serializable
             return new ApplitoolsBuildWrapper(
                     formData.getString("serverURL"),
                     formData.getBoolean("notifyOnCompletion"),
-                    formData.getString("applitoolsApiKey"),
+                    Secret.fromString(formData.getString("applitoolsApiKey")),
                     formData.getBoolean("dontCloseBatches"),
                     formData.getBoolean("eyesScmIntegrationEnabled"));
         }

--- a/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
@@ -154,14 +154,14 @@ public class ApplitoolsCommon {
             }
 
             String apiKeySysEnv = System.getenv("APPLITOOLS_API_KEY");
-            if (applitoolsApiKey.equals(apiKeySysEnv)) {
+            if (applitoolsApiKey.getPlainText().equals(apiKeySysEnv)) {
                 listener.getLogger().println("API Key is the same as the one in the system environment variable APPLITOOLS_API_KEY");
             } else {
                 listener.getLogger().println("API Key is different from the one in the system environment variable APPLITOOLS_API_KEY");
             }
 
             String apiKeyEnv = env.get("APPLITOOLS_API_KEY");
-            if (applitoolsApiKey.equals(apiKeyEnv)) {
+            if (applitoolsApiKey.getPlainText().equals(apiKeyEnv)) {
                 listener.getLogger().println("API Key is the same as the one in the environment variable APPLITOOLS_API_KEY");
             } else {
                 listener.getLogger().println("API Key is different from the one in the environment variable APPLITOOLS_API_KEY");

--- a/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsCommon.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import hudson.util.Secret;
 import jenkins.model.ArtifactManager;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
@@ -54,7 +55,7 @@ public class ApplitoolsCommon {
 
     @SuppressWarnings("rawtypes")
     public static void integrateWithApplitools(Run run, String serverURL, boolean notifyOnCompletion,
-                                               String applitoolsApiKey, boolean dontCloseBatches,
+                                               Secret applitoolsApiKey, boolean dontCloseBatches,
                                                boolean eyesScmIntegrationEnabled
     ) throws IOException {
         updateProjectProperties(run, serverURL, notifyOnCompletion, applitoolsApiKey, dontCloseBatches, eyesScmIntegrationEnabled);
@@ -64,7 +65,7 @@ public class ApplitoolsCommon {
 
     @SuppressWarnings("rawtypes")
     private static void updateProjectProperties(Run run, String serverURL, boolean notifyOnCompletion,
-                                                String applitoolsApiKey, boolean dontCloseBatches,
+                                                Secret applitoolsApiKey, boolean dontCloseBatches,
                                                 boolean eyesScmIntegrationEnabled
     ) throws IOException {
         boolean found = false;
@@ -95,7 +96,7 @@ public class ApplitoolsCommon {
         }
     }
 
-    private static void sendBindBatchPointersRequest(String serverURL, String batchId, String buildId, String apiKey,
+    private static void sendBindBatchPointersRequest(String serverURL, String batchId, String buildId, Secret apiKey,
                                                      final TaskListener listener)
             throws IOException {
         HttpClient httpClient = HttpClientBuilder.create().build();
@@ -103,7 +104,7 @@ public class ApplitoolsCommon {
         try {
             targetUrl = new URIBuilder(serverURL)
                     .setPath(String.format(BATCH_BIND_POINTERS_PATH, buildId))
-                    .addParameter("apiKey", apiKey)
+                    .addParameter("apiKey", apiKey.getPlainText())
                     .build();
         } catch (URISyntaxException e) {
             logger.warning("Couldn't build URI: " + e.getMessage());
@@ -134,7 +135,7 @@ public class ApplitoolsCommon {
 
     public static void buildEnvVariablesForExternalUsage(Map<String, String> env, final Run<?, ?> build,
                                                          final TaskListener listener, FilePath workspace,
-                                                         Launcher launcher, String serverURL, String applitoolsApiKey,
+                                                         Launcher launcher, String serverURL, Secret applitoolsApiKey,
                                                          Map<String, String> artifacts, boolean scmIntegrationEnabled) {
         ApplitoolsCommon.env = env;
         String projectName = build.getParent().getDisplayName();
@@ -172,15 +173,17 @@ public class ApplitoolsCommon {
                 listener.getLogger().println("System env var APPLITOOLS_API_KEY is different from the loaded env var");
             }
 
+            String decryptedApiKey = applitoolsApiKey.getPlainText();
+
             listener.getLogger().println("APPLITOOLS_SHOW_API_KEY exists in global context: " + System.getenv().containsKey("APPLITOOLS_SHOW_API_KEY"));
             listener.getLogger().println("APPLITOOLS_SHOW_API_KEY exists in local context: " + env.containsKey("APPLITOOLS_SHOW_API_KEY"));
-            listener.getLogger().println("API KEY length: " + applitoolsApiKey.length());
+            listener.getLogger().println("API KEY length: " + decryptedApiKey.length());
 
-            if (applitoolsApiKey.length() > 10) {
-                listener.getLogger().println("Partial API KEY: " + applitoolsApiKey.substring(0, 5)+"..."+applitoolsApiKey.substring(applitoolsApiKey.length()-5));
+            if (decryptedApiKey.length() > 10) {
+                listener.getLogger().println("Partial API KEY: " + decryptedApiKey.substring(0, 5)+"..."+decryptedApiKey.substring(decryptedApiKey.length()-5));
             }
             if (System.getenv().containsKey("APPLITOOLS_SHOW_API_KEY") || env.containsKey("APPLITOOLS_SHOW_API_KEY")) {
-                listener.getLogger().println("APPLITOOLS_SHOW_API_KEY exists. API KEY: " + splitAndJoin(applitoolsApiKey, 5, "-"));
+                listener.getLogger().println("APPLITOOLS_SHOW_API_KEY exists. API KEY: " + splitAndJoin(decryptedApiKey, 5, "-"));
             } else {
                 listener.getLogger().println("APPLITOOLS_SHOW_API_KEY does not exist.");
             }
@@ -240,9 +243,9 @@ public class ApplitoolsCommon {
     }
 
     public static void closeBatch(Run<?, ?> run, TaskListener listener, String serverURL,
-                                  boolean notifyOnCompletion, String applitoolsApiKey, boolean scmIntegrationEnabled)
+                                  boolean notifyOnCompletion, Secret applitoolsApiKey, boolean scmIntegrationEnabled)
             throws IOException {
-        if (notifyOnCompletion && applitoolsApiKey != null && !applitoolsApiKey.isEmpty()) {
+        if (notifyOnCompletion && applitoolsApiKey != null && !applitoolsApiKey.getPlainText().isEmpty()) {
             String batchId = ApplitoolsStatusDisplayAction.generateBatchId(
                     env,
                     run.getParent().getDisplayName(),
@@ -259,7 +262,7 @@ public class ApplitoolsCommon {
             try {
                 targetUrl = new URIBuilder(serverURL)
                         .setPath(String.format(BATCH_NOTIFICATION_PATH, batchId))
-                        .addParameter("apiKey", applitoolsApiKey)
+                        .addParameter("apiKey", applitoolsApiKey.getPlainText())
                         .build();
             } catch (URISyntaxException e) {
                 logger.warning("Couldn't build URI: " + e.getMessage());

--- a/src/main/java/com/applitools/jenkins/ApplitoolsEnvironmentUtil.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsEnvironmentUtil.java
@@ -2,6 +2,7 @@ package com.applitools.jenkins;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.Secret;
 
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public class ApplitoolsEnvironmentUtil {
 
     public static void outputVariables(final TaskListener listener, Run<?, ?> build,
                                        Map<String, String> env, String serverURL, String batchName,
-                                       String batchId, String projectName, String applitoolsApiKey) {
+                                       String batchId, String projectName, Secret applitoolsApiKey) {
         listener.getLogger().println("Creating Applitools environment variables:");
 
         outputEnvironmentVariable(listener, env, APPLITOOLS_DONT_CLOSE_BATCHES, TRUE_VALUE, true);
@@ -42,8 +43,11 @@ public class ApplitoolsEnvironmentUtil {
             outputEnvironmentVariable(listener, env, APPLITOOLS_BATCH_SEQUENCE, projectName, true);
         }
 
-        if (applitoolsApiKey != null && !applitoolsApiKey.isEmpty()) {
-            outputEnvironmentVariable(listener, env, APPLITOOLS_API_KEY, applitoolsApiKey, true);
+        if (applitoolsApiKey != null) {
+            String decryptedApiKey = applitoolsApiKey.getPlainText();
+            if (!decryptedApiKey.isEmpty()) {
+                outputEnvironmentVariable(listener, env, APPLITOOLS_API_KEY, decryptedApiKey, true);
+            }
         }
     }
 

--- a/src/main/java/com/applitools/jenkins/ApplitoolsJobDsl.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsJobDsl.java
@@ -1,6 +1,7 @@
 package com.applitools.jenkins;
 
 import hudson.Extension;
+import hudson.util.Secret;
 import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
@@ -19,14 +20,14 @@ public class ApplitoolsJobDsl extends ContextExtensionPoint {
     }
 
     @DslExtensionMethod(context = WrapperContext.class)
-    public Object applitools(String serverUrl, boolean notifyOnCompletion, String apiKey) {
+    public Object applitools(String serverUrl, boolean notifyOnCompletion, Secret apiKey) {
         return new ApplitoolsBuildWrapper(
                 serverUrl, notifyOnCompletion, apiKey, false, false);
     }
 
 
     @DslExtensionMethod(context = WrapperContext.class)
-    public Object applitools(String serverUrl, String apiKey) {
+    public Object applitools(String serverUrl, Secret apiKey) {
         return new ApplitoolsBuildWrapper(
                 serverUrl, true, apiKey, false, false);
     }

--- a/src/main/java/com/applitools/jenkins/ApplitoolsProjectConfigProperty.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsProjectConfigProperty.java
@@ -6,6 +6,7 @@ import hudson.model.JobPropertyDescriptor;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
+import hudson.util.Secret;
 
 import java.io.Serializable;
 
@@ -15,11 +16,11 @@ import java.io.Serializable;
 public class ApplitoolsProjectConfigProperty extends JobProperty<AbstractProject<?, ?>> implements Serializable{
     private String serverURL;
     private boolean notifyOnCompletion;
-    private String applitoolsApiKey;
+    private Secret applitoolsApiKey;
     private boolean dontCloseBatches;
     private boolean eyesScmIntegrationEnabled;
 
-    public ApplitoolsProjectConfigProperty(String serverURL, boolean notifyOnCompletion, String applitoolsApiKey,
+    public ApplitoolsProjectConfigProperty(String serverURL, boolean notifyOnCompletion, Secret applitoolsApiKey,
                                            boolean dontCloseBatches, boolean eyesScmIntegrationEnabled) {
         this.serverURL = serverURL;
         this.notifyOnCompletion = notifyOnCompletion;
@@ -28,11 +29,11 @@ public class ApplitoolsProjectConfigProperty extends JobProperty<AbstractProject
         this.eyesScmIntegrationEnabled = eyesScmIntegrationEnabled;
     }
 
-    public String getApplitoolsApiKey() {
+    public Secret getApplitoolsApiKey() {
         return applitoolsApiKey;
     }
 
-    public void setApplitoolsApiKey(String value) {
+    public void setApplitoolsApiKey(Secret value) {
         this.applitoolsApiKey = value;
     }
 

--- a/src/main/java/com/applitools/jenkins/ApplitoolsStep.java
+++ b/src/main/java/com/applitools/jenkins/ApplitoolsStep.java
@@ -12,6 +12,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import hudson.util.Secret;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -27,14 +29,14 @@ import static com.applitools.jenkins.ApplitoolsBuildWrapper.isCustomBatchId;
 public class ApplitoolsStep extends AbstractStepImpl {
     private String serverURL;
     private final boolean notifyOnCompletion;
-    private final String applitoolsApiKey;
+    private final Secret applitoolsApiKey;
     private final boolean dontCloseBatches;
     private final boolean eyesScmIntegrationEnabled;
 
     @DataBoundConstructor
     public ApplitoolsStep(String serverURL,
                           boolean notifyOnCompletion,
-                          String applitoolsApiKey,
+                          Secret applitoolsApiKey,
                           boolean dontCloseBatches,
                           boolean eyesScmIntegrationEnabled)
     {
@@ -53,7 +55,7 @@ public class ApplitoolsStep extends AbstractStepImpl {
         return ApplitoolsCommon.APPLITOOLS_DEFAULT_URL;
     }
 
-    public String getApplitoolsApiKey() {
+    public Secret getApplitoolsApiKey() {
         return this.applitoolsApiKey;
     }
 
@@ -200,7 +202,7 @@ public class ApplitoolsStep extends AbstractStepImpl {
             return new ApplitoolsStep(
                     formData.getString("serverURL"),
                     formData.getBoolean("notifyOnCompletion"),
-                    formData.getString("applitoolsApiKey"),
+                    Secret.fromString(formData.getString("applitoolsApiKey")),
                     formData.getBoolean("dontCloseBatches"),
                     formData.getBoolean("eyesScmIntegrationEnabled")
                     );

--- a/src/main/resources/com/applitools/jenkins/ApplitoolsBuildWrapper/config.jelly
+++ b/src/main/resources/com/applitools/jenkins/ApplitoolsBuildWrapper/config.jelly
@@ -5,7 +5,7 @@
         <f:textbox default="${descriptor.APPLITOOLS_DEFAULT_URL}"/>
     </f:entry>
     <f:entry title="${%applitoolsApiKey.text.text}" field="applitoolsApiKey">
-        <f:textbox />
+        <f:password />
     </f:entry>
     <f:entry title="${%notifyOnCompletion.text.text}" field="notifyOnCompletion">
         <f:checkbox default="${descriptor.NOTIFY_ON_COMPLETION}"/>

--- a/src/main/resources/com/applitools/jenkins/ApplitoolsStep/config.jelly
+++ b/src/main/resources/com/applitools/jenkins/ApplitoolsStep/config.jelly
@@ -5,7 +5,7 @@
         <f:textbox default="${descriptor.APPLITOOLS_DEFAULT_URL}"/>
     </f:entry>
     <f:entry title="${%applitoolsApiKey.text.text}" field="applitoolsApiKey">
-        <f:textbox />
+        <f:password />
     </f:entry>
     <f:entry title="${%notifyOnCompletion.text.text}" field="notifyOnCompletion">
         <f:checkbox default="${descriptor.NOTIFY_ON_COMPLETION}"/>


### PR DESCRIPTION
Manually entered API Key was stored as plain text, so I converted it to <f:password /> and corresponding Secret class.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
